### PR TITLE
Fix for blog post authors' avatar display

### DIFF
--- a/_assets/stylesheets/theme.css.erb
+++ b/_assets/stylesheets/theme.css.erb
@@ -1015,6 +1015,9 @@ blockquote p:after {
 img.author {
   width: 80px;
   height: 80px;
+}
+
+#blog img.author {
   margin-top: -40px;
 }
 


### PR DESCRIPTION
When viewing a single blog post, the author's avatar image was cropped off at the top. Restricting the margin-top:-40px rule to avatars on the blog's overview page fixes that.

Before: 
![screen shot 2015-05-11 at 18 46 12](https://cloud.githubusercontent.com/assets/264472/7570460/b2b10296-f810-11e4-8d46-66206832ef75.png)
After:
![screen shot 2015-05-11 at 18 46 21](https://cloud.githubusercontent.com/assets/264472/7570463/b9958546-f810-11e4-893d-d17aa7a9f19f.png)
