### PR TITLE
Fix about two thirds of the 169 failures reported by Travis CI by adding alt attributes to imgs

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ is_post: true
     <div class="container">
     <div class="row">
       <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
-	<img class="author img-responsive img-circle" src="https://avatars.githubusercontent.com/{{ page.author }}"/>
+	<img class="author img-responsive img-circle" src="https://avatars.githubusercontent.com/{{ page.author }}" alt="{{ page.author }}’s GitHub avatar"/>
 	{% assign title_parts = page.title | split: ' >> ' %}
 	<h2 class="post-title">
 	  {{ title_parts[1] }}

--- a/blog/index.html
+++ b/blog/index.html
@@ -19,7 +19,7 @@ active: blog
     <div class="row">
       <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
 	<div class="panel panel-default">
-	  <img class="author img-responsive img-circle" src="https://avatars.githubusercontent.com/{{ post.author }}" onerror="this.style.display='none'"/>
+	  <img class="author img-responsive img-circle" src="https://avatars.githubusercontent.com/{{ post.author }}" alt="{{ post.author }}’s GitHub avatar" onerror="this.style.display='none'"/>
 	  <div class="panel-body">
             <div class="post-preview">
 	      <h2 class="post-title">


### PR DESCRIPTION
These two commits should fix about two thirds of the 169 failures reported by Travis CI by adding alt attributes to imgs.

Once the Travis CI failures log cleans, I'd like to fix the rest of the failures.

Cheers.